### PR TITLE
Enhance check version consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
 
-      - name: Check version consistency
-        run: elixir bin/check_version_consistency.exs
-
       - name: Run tests
         run: |
           mix test
@@ -68,6 +65,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-${{ env.MIX_ENV }}-${{ hashFiles('.tool-versions') }}-
             ${{ runner.os }}-mix-
+
+      - name: Check version consistency
+        run: elixir bin/check_version_consistency.exs
 
       - name: Prepare mix
         run: |

--- a/.github/workflows/publish2hex.yml
+++ b/.github/workflows/publish2hex.yml
@@ -27,6 +27,9 @@ jobs:
             ${{ runner.os }}-${{ hashFiles('.tool-versions') }}-
             ${{ runner.os }}-mix-
 
+      - name: Check version consistency
+        run: elixir bin/check_version_consistency.exs
+
       - name: Prepare mix
         run: |
           mix local.hex --force
@@ -34,9 +37,6 @@ jobs:
 
       - name: Install dependencies
         run: mix deps.get
-
-      - name: Check version consistency
-        run: elixir bin/check_version_consistency.exs
 
       - name: Run tests
         run: |

--- a/bin/check_version_consistency.exs
+++ b/bin/check_version_consistency.exs
@@ -7,6 +7,7 @@ defmodule CheckVersions do
 
     errors =
       errors
+      |> check_app_versions_file(versions)
       |> check_root_dockerfile(versions)
       |> check_apps_dockerfiles(versions)
       |> check_docker_compose(versions)
@@ -76,6 +77,23 @@ defmodule CheckVersions do
     end
 
     versions
+  end
+
+  defp check_app_versions_file(errors, _versions) do
+    root_file = "VERSIONS"
+    app_file = "apps/giocci/VERSIONS"
+
+    root_content = File.read!(root_file)
+    app_content = File.read!(app_file)
+
+    if root_content == app_content do
+      errors
+    else
+      [
+        "#{app_file}: not copied from #{root_file} (need to run any mix tasks before push)"
+        | errors
+      ]
+    end
   end
 
   defp check_root_dockerfile(errors, versions) do


### PR DESCRIPTION
これのきっかけとして，なんかしら mix task (root で `mix deps.get` とか) を走らせたら ./VERSIONS を apps/giocci/VERSIONS に自動コピーしているが，v0.4.1 リリース時にそれをせずに push & merge & release に至ってしまったこと,,, 
https://github.com/biyooon-ex/giocci_platform/blob/v0.4.1/apps/giocci/VERSIONS

hex2publish.yml でコピられてそれが hex.pm 公開されているので難を逃れたが，これをちゃんと検知するために改良した．

- check_version_consistency で上記２ファイルが一致しているか検知 `check_app_versions_file`
- check_version_consistency を CI の冒頭（`mix deps.get` より前）に移動
  - test より code-analysis が馴染むので移動させた