### PR TITLE
Remove dependabot configuration of child projects in Umbrella

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "mix"
-    directory: "/apps/giocci"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "zenohex"
-  - package-ecosystem: "mix"
-    directory: "/apps/giocci_relay"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "zenohex"
-  - package-ecosystem: "mix"
-    directory: "/apps/giocci_engine"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "zenohex"
-  - package-ecosystem: "mix"
-    directory: "/apps/giocci_integration_test"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
下記を観測する感じでは `/` のみ監視すれば Umbrella の子プロジェクトもちゃんと見てくれてそうなので．
https://github.com/biyooon-ex/giocci_platform/network/updates
https://github.com/biyooon-ex/giocci_platform/network/updates/18919755/jobs
https://github.com/biyooon-ex/giocci_platform/pull/90

いちおう無理くりな追い検証してみてから merge する．