### PR TITLE
Fix Zenoh config loading issue and improve integration tests

### DIFF
--- a/apps/giocci/lib/giocci/session_manager.ex
+++ b/apps/giocci/lib/giocci/session_manager.ex
@@ -25,7 +25,13 @@ defmodule Giocci.SessionManager do
           |> insert_json5!("mode", "client")
 
         zenoh_config_file_path ->
-          Zenohex.Config.from_file(zenoh_config_file_path)
+          case Zenohex.Config.from_file(zenoh_config_file_path) do
+            {:ok, config} ->
+              config
+
+            {:error, reason} ->
+              raise "Failed to load Zenoh config file from (#{zenoh_config_file_path}): #{inspect(reason)}"
+          end
       end
 
     zenoh_config =

--- a/apps/giocci_engine/lib/giocci_engine/session_manager.ex
+++ b/apps/giocci_engine/lib/giocci_engine/session_manager.ex
@@ -25,7 +25,13 @@ defmodule GiocciEngine.SessionManager do
           |> insert_json5!("mode", "client")
 
         zenoh_config_file_path ->
-          Zenohex.Config.from_file(zenoh_config_file_path)
+          case Zenohex.Config.from_file(zenoh_config_file_path) do
+            {:ok, config} ->
+              config
+
+            {:error, reason} ->
+              raise "Failed to load Zenoh config file from (#{zenoh_config_file_path}): #{inspect(reason)}"
+          end
       end
 
     zenoh_config =

--- a/apps/giocci_integration_test/test/giocci_integration_test_test.exs
+++ b/apps/giocci_integration_test/test/giocci_integration_test_test.exs
@@ -6,6 +6,9 @@ defmodule GiocciIntegrationTestTest do
   @relay_name "giocci_relay"
   @engine_name "giocci_engine"
   @client_name "giocci"
+  @giocci_zenoh_config_path Path.expand("../../giocci/config/zenoh.json5", __DIR__)
+  @giocci_relay_zenoh_config_path Path.expand("../../giocci_relay/config/zenoh.json5", __DIR__)
+  @giocci_engine_zenoh_config_path Path.expand("../../giocci_engine/config/zenoh.json5", __DIR__)
 
   # Timeout for waiting engine response after it's stopped
   @engine_stopped_timeout 1000
@@ -228,6 +231,44 @@ defmodule GiocciIntegrationTestTest do
 
     test "commas-only: does not override connect.endpoints and normal scenario works" do
       System.put_env("ZENOHD_CONNECT_ENDPOINTS", ",,")
+      setup_relay_and_client()
+      setup_engine()
+
+      assert :ok == Giocci.register_client(@relay_name)
+      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
+      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+    end
+  end
+
+  describe "operation with zenoh_config_file_path" do
+    setup do
+      System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447")
+      :ok = Application.put_env(:giocci, :zenoh_config_file_path, @giocci_zenoh_config_path)
+
+      :ok =
+        Application.put_env(
+          :giocci_relay,
+          :zenoh_config_file_path,
+          @giocci_relay_zenoh_config_path
+        )
+
+      :ok =
+        Application.put_env(
+          :giocci_engine,
+          :zenoh_config_file_path,
+          @giocci_engine_zenoh_config_path
+        )
+
+      on_exit(fn ->
+        :ok = Application.delete_env(:giocci, :zenoh_config_file_path)
+        :ok = Application.delete_env(:giocci_relay, :zenoh_config_file_path)
+        :ok = Application.delete_env(:giocci_engine, :zenoh_config_file_path)
+      end)
+
+      :ok
+    end
+
+    test "all components start and normal scenario works with zenoh_config_file_path" do
       setup_relay_and_client()
       setup_engine()
 

--- a/apps/giocci_integration_test/test/giocci_integration_test_test.exs
+++ b/apps/giocci_integration_test/test/giocci_integration_test_test.exs
@@ -248,6 +248,7 @@ defmodule GiocciIntegrationTestTest do
         :ok = Application.delete_env(:giocci, :zenoh_config_file_path)
         :ok = Application.delete_env(:giocci_relay, :zenoh_config_file_path)
         :ok = Application.delete_env(:giocci_engine, :zenoh_config_file_path)
+        :ok = System.delete_env("ZENOHD_CONNECT_ENDPOINTS")
       end)
 
       :ok

--- a/apps/giocci_integration_test/test/giocci_integration_test_test.exs
+++ b/apps/giocci_integration_test/test/giocci_integration_test_test.exs
@@ -171,14 +171,14 @@ defmodule GiocciIntegrationTestTest do
   describe "operation when ZENOHD_CONNECT_ENDPOINTS is set" do
     setup do
       on_exit(fn ->
-        System.delete_env("ZENOHD_CONNECT_ENDPOINTS")
+        :ok = System.delete_env("ZENOHD_CONNECT_ENDPOINTS")
       end)
 
       :ok
     end
 
     test "single endpoint: connects all components and normal scenario works" do
-      System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447")
+      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447")
       setup_relay_and_client()
       setup_engine()
 
@@ -190,7 +190,7 @@ defmodule GiocciIntegrationTestTest do
     test "multiple comma-separated endpoints with spaces: connects and works" do
       # Using the same endpoint twice to test the comma-separated parsing while keeping
       # the test self-contained on a single local machine
-      System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447, tcp/localhost:7447")
+      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447, tcp/localhost:7447")
       setup_relay_and_client()
       setup_engine()
 
@@ -200,7 +200,7 @@ defmodule GiocciIntegrationTestTest do
     end
 
     test "trailing comma with whitespace: whitespace-only segments are ignored" do
-      System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447, ")
+      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447, ")
       setup_relay_and_client()
       setup_engine()
 
@@ -210,7 +210,7 @@ defmodule GiocciIntegrationTestTest do
     end
 
     test "empty string: does not override connect.endpoints and normal scenario works" do
-      System.put_env("ZENOHD_CONNECT_ENDPOINTS", "")
+      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "")
       setup_relay_and_client()
       setup_engine()
 
@@ -220,7 +220,7 @@ defmodule GiocciIntegrationTestTest do
     end
 
     test "whitespace-only: does not override connect.endpoints and normal scenario works" do
-      System.put_env("ZENOHD_CONNECT_ENDPOINTS", "   ")
+      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "   ")
       setup_relay_and_client()
       setup_engine()
 
@@ -230,7 +230,7 @@ defmodule GiocciIntegrationTestTest do
     end
 
     test "commas-only: does not override connect.endpoints and normal scenario works" do
-      System.put_env("ZENOHD_CONNECT_ENDPOINTS", ",,")
+      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", ",,")
       setup_relay_and_client()
       setup_engine()
 
@@ -242,7 +242,7 @@ defmodule GiocciIntegrationTestTest do
 
   describe "operation with zenoh_config_file_path" do
     setup do
-      System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447")
+      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447")
       :ok = Application.put_env(:giocci, :zenoh_config_file_path, @giocci_zenoh_config_path)
 
       :ok =

--- a/apps/giocci_integration_test/test/giocci_integration_test_test.exs
+++ b/apps/giocci_integration_test/test/giocci_integration_test_test.exs
@@ -189,9 +189,11 @@ defmodule GiocciIntegrationTestTest do
     end
 
     test "multiple comma-separated endpoints with spaces: connects and works" do
-      # Using the same endpoint twice to test the comma-separated parsing while keeping
-      # the test self-contained on a single local machine
-      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447, tcp/localhost:7447")
+      # Using the multiple endpoints to test the comma-separated parsing while keeping
+      # the test self-contained on a local machine
+      :ok =
+        System.put_env("ZENOHD_CONNECT_ENDPOINTS", "tcp/localhost:7447, tcp/192.168.0.95:7447")
+
       setup_relay_and_client()
       setup_engine()
 
@@ -208,14 +210,6 @@ defmodule GiocciIntegrationTestTest do
 
     test "empty string: does not override connect.endpoints and normal scenario works" do
       :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "")
-      setup_relay_and_client()
-      setup_engine()
-
-      assert_normal_scenario_works()
-    end
-
-    test "whitespace-only: does not override connect.endpoints and normal scenario works" do
-      :ok = System.put_env("ZENOHD_CONNECT_ENDPOINTS", "   ")
       setup_relay_and_client()
       setup_engine()
 

--- a/apps/giocci_integration_test/test/giocci_integration_test_test.exs
+++ b/apps/giocci_integration_test/test/giocci_integration_test_test.exs
@@ -51,6 +51,24 @@ defmodule GiocciIntegrationTestTest do
     :ok
   end
 
+  defp assert_normal_scenario_works do
+    assert :ok == Giocci.register_client(@relay_name)
+    assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
+    assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+
+    assert {:error, "function_not_defined: {GiocciIntegrationTest, :undefined_function, []}"} ==
+             Giocci.exec_func(
+               @relay_name,
+               {GiocciIntegrationTest, :undefined_function, []}
+             )
+
+    :ok = Giocci.exec_func_async(@relay_name, {GiocciIntegrationTest, :add, [1, 2]}, self())
+
+    assert_receive {:giocci, 3},
+                   @async_message_timeout,
+                   "Expected async response with result 3"
+  end
+
   describe "happy path" do
     setup do
       setup_relay_and_client()
@@ -59,22 +77,7 @@ defmodule GiocciIntegrationTestTest do
     end
 
     test "normal scenario" do
-      assert :ok == Giocci.register_client(@relay_name)
-      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
-      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
-
-      assert {:error, "function_not_defined: {GiocciIntegrationTest, :undefined_function, []}"} ==
-               Giocci.exec_func(
-                 @relay_name,
-                 {GiocciIntegrationTest, :undefined_function, []}
-               )
-
-      :ok =
-        Giocci.exec_func_async(@relay_name, {GiocciIntegrationTest, :add, [1, 2]}, self())
-
-      assert_receive {:giocci, 3},
-                     @async_message_timeout,
-                     "Expected async response with result 3"
+      assert_normal_scenario_works()
     end
   end
 
@@ -182,9 +185,7 @@ defmodule GiocciIntegrationTestTest do
       setup_relay_and_client()
       setup_engine()
 
-      assert :ok == Giocci.register_client(@relay_name)
-      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
-      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+      assert_normal_scenario_works()
     end
 
     test "multiple comma-separated endpoints with spaces: connects and works" do
@@ -194,9 +195,7 @@ defmodule GiocciIntegrationTestTest do
       setup_relay_and_client()
       setup_engine()
 
-      assert :ok == Giocci.register_client(@relay_name)
-      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
-      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+      assert_normal_scenario_works()
     end
 
     test "trailing comma with whitespace: whitespace-only segments are ignored" do
@@ -204,9 +203,7 @@ defmodule GiocciIntegrationTestTest do
       setup_relay_and_client()
       setup_engine()
 
-      assert :ok == Giocci.register_client(@relay_name)
-      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
-      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+      assert_normal_scenario_works()
     end
 
     test "empty string: does not override connect.endpoints and normal scenario works" do
@@ -214,9 +211,7 @@ defmodule GiocciIntegrationTestTest do
       setup_relay_and_client()
       setup_engine()
 
-      assert :ok == Giocci.register_client(@relay_name)
-      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
-      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+      assert_normal_scenario_works()
     end
 
     test "whitespace-only: does not override connect.endpoints and normal scenario works" do
@@ -224,9 +219,7 @@ defmodule GiocciIntegrationTestTest do
       setup_relay_and_client()
       setup_engine()
 
-      assert :ok == Giocci.register_client(@relay_name)
-      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
-      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+      assert_normal_scenario_works()
     end
 
     test "commas-only: does not override connect.endpoints and normal scenario works" do
@@ -234,9 +227,7 @@ defmodule GiocciIntegrationTestTest do
       setup_relay_and_client()
       setup_engine()
 
-      assert :ok == Giocci.register_client(@relay_name)
-      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
-      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+      assert_normal_scenario_works()
     end
   end
 
@@ -272,9 +263,7 @@ defmodule GiocciIntegrationTestTest do
       setup_relay_and_client()
       setup_engine()
 
-      assert :ok == Giocci.register_client(@relay_name)
-      assert :ok == Giocci.save_module(@relay_name, GiocciIntegrationTest)
-      assert 3 == Giocci.exec_func(@relay_name, {GiocciIntegrationTest, :add, [1, 2]})
+      assert_normal_scenario_works()
     end
   end
 

--- a/apps/giocci_relay/lib/giocci_relay/session_manager.ex
+++ b/apps/giocci_relay/lib/giocci_relay/session_manager.ex
@@ -23,7 +23,13 @@ defmodule GiocciRelay.SessionManager do
           |> insert_json5!("mode", "client")
 
         zenoh_config_file_path ->
-          Zenohex.Config.from_file(zenoh_config_file_path)
+          case Zenohex.Config.from_file(zenoh_config_file_path) do
+            {:ok, config} ->
+              config
+
+            {:error, reason} ->
+              raise "Failed to load Zenoh config file from (#{zenoh_config_file_path}): #{inspect(reason)}"
+          end
       end
 
     zenoh_config =


### PR DESCRIPTION
だいぶやらかしてしまった,,, SessionMananger の `init/1` にバグがありました,,,;(  

Zenohex v0.9.0 に移行する際に調子に乗って `Zenohex.Config.from_file/1` に変更しました．
https://github.com/biyooon-ex/giocci_platform/pull/98/changes#diff-101d833f7f75845d73737f5ee2619d6f16787740067818cea048c54e553837d8L27-R28

このAPIは `{:ok, t()} | {:error, reason :: term()}` を返しますが，直接で `config` を返すようにしてしまっていたため，後段の `Zenohex.Session.open(zenoh_config)` で失敗しちゃっていました．クラウドも絡めた ZenohExamples で動かして初めて気づいた,,, 

この問題を検知するための GiocciIntegrationTest `all components start and normal scenario works with zenoh_config_file_path` も追加しました．

合わせて，前回に追加した ZENOHD_CONNECT_ENDPOINTS について，下記も修正しました．
- `:ok = System.put_env` みたいな感じで既存の `:ok = Application.put_env`と統一（気持ちよさの問題）
- `assert_normal_scenario_works` をヘルパー関数としてくくって使い回すようにした
- `ZENOHD_CONNECT_ENDPOINTS` で localhost と別サーバを指定するケースに変更 && whitespace-only case はちょっと冗長な気がするので削除（他にも削れそうだけど）