### PR TITLE
Add GitHub Actions workflow for releasing Giocci container assets

### DIFF
--- a/.github/workflows/publish2hex.yml
+++ b/.github/workflows/publish2hex.yml
@@ -1,9 +1,9 @@
 name: publish2hex
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types:
+      - published
 
 jobs:
   publish2hex:

--- a/.github/workflows/release-assets-for-giocci-containers.yml
+++ b/.github/workflows/release-assets-for-giocci-containers.yml
@@ -1,9 +1,9 @@
 name: Release Assets for Giocci Containers
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       tag:
@@ -48,4 +48,4 @@ jobs:
             giocci_relay.zip
             giocci_engine.zip
           overwrite_files: true
-          generate_release_notes: true
+          generate_release_notes: false

--- a/.github/workflows/release-assets-for-giocci-containers.yml
+++ b/.github/workflows/release-assets-for-giocci-containers.yml
@@ -1,0 +1,51 @@
+name: Release Assets for Giocci Containers
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to upload assets to (e.g. v0.5.1)
+        required: true
+        type: string
+
+jobs:
+  upload-giocci-container-release-assets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Build giocci_relay.zip
+        shell: bash
+        run: |
+          mkdir -p release_assets/giocci_relay
+          cp -R apps/giocci_relay/config release_assets/giocci_relay/
+          cp apps/giocci_relay/docker-compose.yml release_assets/giocci_relay/
+          cd release_assets/giocci_relay
+          zip -r ../../giocci_relay.zip config docker-compose.yml
+
+      - name: Build giocci_engine.zip
+        shell: bash
+        run: |
+          mkdir -p release_assets/giocci_engine
+          cp -R apps/giocci_engine/config release_assets/giocci_engine/
+          cp apps/giocci_engine/docker-compose.yml release_assets/giocci_engine/
+          cd release_assets/giocci_engine
+          zip -r ../../giocci_engine.zip config docker-compose.yml
+
+      - name: Upload asset to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: |
+            giocci_relay.zip
+            giocci_engine.zip
+          overwrite_files: true
+          generate_release_notes: true

--- a/apps/giocci_engine/README.md
+++ b/apps/giocci_engine/README.md
@@ -10,7 +10,7 @@ GiocciEngine is the execution engine component of the GiocciPlatform that receiv
 
 ## How to run giocci_engine on your server
 
-1. Download `giocci_engine.zip` from the GitHub Releases page and extract it in your working directory (`v0.5.1` and later)
+1. Download `giocci_engine.zip` from the [GiocciPlatform Releases page](https://github.com/biyooon-ex/giocci_platform/releases) and extract it in your working directory (`v0.5.1` and later)
    - The zip contains `./config/` and `./docker-compose.yml`
    - For stable operation, we recommend using the same release version across API and containers.
 

--- a/apps/giocci_engine/README.md
+++ b/apps/giocci_engine/README.md
@@ -10,10 +10,12 @@ GiocciEngine is the execution engine component of the GiocciPlatform that receiv
 
 ## How to run giocci_engine on your server
 
-1. Download `./config` and `./docker-compose.yml` to your working directory
+1. Download `giocci_engine.zip` from the GitHub Releases page and extract it in your working directory (`v0.5.1` and later)
+   - The zip contains `./config/` and `./docker-compose.yml`
+   - For stable operation, we recommend using the same release version across API and containers.
 
 2. Edit `config/zenoh.json5` to configure Zenoh connection:
-   - This file is copied from [the official Zenoh repository](https://github.com/eclipse-zenoh/zenoh/blob/main/DEFAULT_CONFIG.json5) and modifiled for Giocci (check `MODIFIED_FOR_GIOCCI` label in the file).
+   - This file is copied from [the official Zenoh repository](https://github.com/eclipse-zenoh/zenoh/blob/main/DEFAULT_CONFIG.json5) and modified for Giocci (check `MODIFIED_FOR_GIOCCI` label in the file).
    - Set `connect.endpoints` to your Zenohd server address (e.g., `["tcp/192.168.1.100:7447"]`)
    - Alternatively, set the `ZENOHD_CONNECT_ENDPOINTS` environment variable (e.g., `ZENOHD_CONNECT_ENDPOINTS=tcp/192.168.1.100:7447`) to avoid storing the IP address in the config file
 

--- a/apps/giocci_relay/README.md
+++ b/apps/giocci_relay/README.md
@@ -9,7 +9,7 @@ GiocciRelay is a relay component for the GiocciPlatform that forwards messages b
 
 ## How to run giocci_relay on your server
 
-1. Download `giocci_relay.zip` from the GitHub Releases page and extract it in your working directory (`v0.5.1` and later)
+1. Download `giocci_relay.zip` from the [GiocciPlatform Releases page](https://github.com/biyooon-ex/giocci_platform/releases) and extract it in your working directory (`v0.5.1` and later)
    - The zip contains `./config/` and `./docker-compose.yml`
    - For stable operation, we recommend using the same release version across API and containers.
 

--- a/apps/giocci_relay/README.md
+++ b/apps/giocci_relay/README.md
@@ -9,10 +9,12 @@ GiocciRelay is a relay component for the GiocciPlatform that forwards messages b
 
 ## How to run giocci_relay on your server
 
-1. Download `./config` and `./docker-compose.yml` to your working directory
+1. Download `giocci_relay.zip` from the GitHub Releases page and extract it in your working directory (`v0.5.1` and later)
+   - The zip contains `./config/` and `./docker-compose.yml`
+   - For stable operation, we recommend using the same release version across API and containers.
 
 2. Edit `config/zenoh.json5` to configure Zenoh connection:
-   - This file is copied from [the official Zenoh repository](https://github.com/eclipse-zenoh/zenoh/blob/main/DEFAULT_CONFIG.json5) and modifiled for Giocci (check `MODIFIED_FOR_GIOCCI` label in the file).
+   - This file is copied from [the official Zenoh repository](https://github.com/eclipse-zenoh/zenoh/blob/main/DEFAULT_CONFIG.json5) and modified for Giocci (check `MODIFIED_FOR_GIOCCI` label in the file).
    - Set `connect.endpoints` to your Zenohd server address (e.g., `["tcp/192.168.1.100:7447"]`)
    - Alternatively, set the `ZENOHD_CONNECT_ENDPOINTS` environment variable (e.g., `ZENOHD_CONNECT_ENDPOINTS=tcp/192.168.1.100:7447`) to avoid storing the IP address in the config file
 


### PR DESCRIPTION
Tag/Release 時に Docker Containers for Giocci Relay and Engine の起動に必要なファイルを Release ページに自動追加する！っというアクションです？？